### PR TITLE
Replace lodash.template with lodash-es

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -5,6 +5,7 @@ const config = {
     '^.+\\.(t|j)s$': '@swc/jest',
   },
   resolver: 'ts-jest-resolver',
+  transformIgnorePatterns: ['node_modules/(?!(lodash-es)/)'],
 };
 
 export default config;

--- a/package.json
+++ b/package.json
@@ -39,8 +39,7 @@
   "prettier": "@shelf/prettier-config",
   "dependencies": {
     "entities": "5.0.0",
-    "lodash.defaults": "4.2.0",
-    "lodash.template": "4.5.0",
+    "lodash-es": "4.17.21",
     "slug": "9.1.0"
   },
   "devDependencies": {
@@ -52,8 +51,7 @@
     "@swc/core": "1.9.3",
     "@swc/jest": "0.2.37",
     "@types/jest": "29.5.14",
-    "@types/lodash.defaults": "4.2.9",
-    "@types/lodash.template": "4.5.3",
+    "@types/lodash-es": "4.17.12",
     "@types/node": "20.8.9",
     "@types/slug": "5.0.9",
     "eslint": "8.57.1",

--- a/src/helpers/anchorize.ts
+++ b/src/helpers/anchorize.ts
@@ -1,4 +1,4 @@
-import template from 'lodash.template';
+import {template} from 'lodash-es';
 import type {Header, Settings} from '../types.js';
 import {getSettings} from '../default-settings.js';
 import {untag} from './untag.js';

--- a/src/helpers/toc.ts
+++ b/src/helpers/toc.ts
@@ -1,4 +1,4 @@
-import template from 'lodash.template';
+import {template} from 'lodash-es';
 import type {Header, Settings} from '../types.js';
 import {getSettings} from '../default-settings.js';
 


### PR DESCRIPTION
Replace lodash.template with lodash-es to streamline dependencies and update type definitions accordingly.