### PR TITLE
Add 2 week pnpm deps quarantine

### DIFF
--- a/package.json
+++ b/package.json
@@ -64,7 +64,7 @@
     "ts-jest-resolver": "2.0.1",
     "typescript": "5.8.3"
   },
-  "packageManager": "pnpm@10.33.0",
+  "packageManager": "pnpm@10.32.1",
   "engines": {
     "node": ">=14"
   },

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,0 +1,6 @@
+trustPolicy: no-downgrade
+blockExoticSubdeps: true
+minimumReleaseAge: 20160
+minimumReleaseAgeExclude:
+  - '@shelf/*'
+ignoreScripts: true


### PR DESCRIPTION
## Summary
- Add pnpm workspace security policies: `trustPolicy`, `blockExoticSubdeps`, `minimumReleaseAge` (2-week quarantine), and `ignoreScripts`
- Excludes `@shelf/*` packages from the quarantine period

🤖 Generated with [Claude Code](https://claude.com/claude-code)